### PR TITLE
pass cached query to onQueryCache instead of null

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -298,7 +298,7 @@ public class LRUQueryCache implements QueryCache, Accountable {
     try {
       Query singleton = uniqueQueries.putIfAbsent(query, query);
       if (singleton == null) {
-        onQueryCache(singleton, LINKED_HASHTABLE_RAM_BYTES_PER_ENTRY + ramBytesUsed(query));
+        onQueryCache(query, LINKED_HASHTABLE_RAM_BYTES_PER_ENTRY + ramBytesUsed(query));
       } else {
         query = singleton;
       }


### PR DESCRIPTION
According to the javadocs, LRUQueryCache.onQueryCache can be used to track usage statistics on cached queries. Unfortunately, due to a bug, the query parameter is always passed as null. This PR fixes the problem.